### PR TITLE
SF-29 | return list of portfolios belonging to a particular user

### DIFF
--- a/src/main/java/com/codingcohorts/controller/PortFolioController.java
+++ b/src/main/java/com/codingcohorts/controller/PortFolioController.java
@@ -4,6 +4,7 @@ import com.codingcohorts.dto.PortfolioDTO;
 import com.codingcohorts.service.PortfolioService;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -20,4 +21,9 @@ public class PortFolioController {
         return portFolioService.getPortfolio(portfolio_id);
     }
    // create a method which will return list of portfolios belonging to a particular user
+   // multiple portfolios can have same user id, because a single user can have multiple portfolios
+   @GetMapping("/portfolios/user/{user_id}")
+   public List<PortfolioDTO> getAllPortfoliosByUserId(@PathVariable Long user_id) {
+       return portFolioService.getAllPortfoliosByUserId(user_id);
+   }
 }

--- a/src/main/java/com/codingcohorts/controller/PortFolioController.java
+++ b/src/main/java/com/codingcohorts/controller/PortFolioController.java
@@ -23,7 +23,10 @@ public class PortFolioController {
    // create a method which will return list of portfolios belonging to a particular user
    // multiple portfolios can have same user id, because a single user can have multiple portfolios
    @GetMapping("/portfolios/user/{user_id}")
-   public List<PortfolioDTO> getAllPortfoliosByUserId(@PathVariable Long user_id) {
-       return portFolioService.getAllPortfoliosByUserId(user_id);
+   public List<PortfolioDTO> getAllPortfoliosByUserId(
+           @PathVariable("user_id")
+           Long userId)
+   {
+       return portFolioService.getAllPortfoliosByUserId(userId);
    }
 }

--- a/src/main/java/com/codingcohorts/repository/PortfolioRepository.java
+++ b/src/main/java/com/codingcohorts/repository/PortfolioRepository.java
@@ -3,6 +3,9 @@ package com.codingcohorts.repository;
 import com.codingcohorts.entity.Portfolio;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.List;
 
 @Repository
-public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {}
+public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+    List<Portfolio> findByUserId(Long userId);
+}

--- a/src/main/java/com/codingcohorts/service/PortfolioService.java
+++ b/src/main/java/com/codingcohorts/service/PortfolioService.java
@@ -24,6 +24,12 @@ public class PortfolioService {
     }
 
     public List<PortfolioDTO> getAllPortfoliosByUserId(Long userId) {
+        if (userId == null) {
+            throw new IllegalArgumentException("User ID cannot be null");
+        }
+        if (userId <= 0) {
+            throw new IllegalArgumentException("User ID must be a positive number");
+        }
         List<Portfolio> portfolios = portFolioRepository.findByUserId(userId);
         if (portfolios.isEmpty()) {
             throw new ResourceNotFoundException("No portfolios found for user with id: " + userId);

--- a/src/main/java/com/codingcohorts/service/PortfolioService.java
+++ b/src/main/java/com/codingcohorts/service/PortfolioService.java
@@ -5,6 +5,8 @@ import com.codingcohorts.entity.Portfolio;
 import com.codingcohorts.exception.ResourceNotFoundException;
 import com.codingcohorts.repository.PortfolioRepository;
 import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class PortfolioService {
@@ -19,6 +21,16 @@ public class PortfolioService {
         Portfolio portfolio = portFolioRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Portfolio not found with id: " + id));
         return mapToDTO(portfolio);
+    }
+
+    public List<PortfolioDTO> getAllPortfoliosByUserId(Long userId) {
+        List<Portfolio> portfolios = portFolioRepository.findByUserId(userId);
+        if (portfolios.isEmpty()) {
+            throw new ResourceNotFoundException("No portfolios found for user with id: " + userId);
+        }
+        return portfolios.stream()
+                .map(PortfolioService::mapToDTO) // Convert each Portfolio entity to PortfolioDTO
+                .collect(Collectors.toList());
     }
 
     public static PortfolioDTO mapToDTO(Portfolio portfolio) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added ability to retrieve all portfolios for a specific user.
	- Implemented new endpoint to fetch user-specific portfolios.

- **Bug Fixes**
	- Includes error handling for cases where no portfolios exist for a user.

The changes enhance portfolio management by allowing users to easily access all their portfolios through a dedicated API endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->